### PR TITLE
Adding the rename team command

### DIFF
--- a/concourse/concoursefakes/fake_team.go
+++ b/concourse/concoursefakes/fake_team.go
@@ -57,6 +57,20 @@ type FakeTeam struct {
 		result3 bool
 		result4 error
 	}
+	RenameTeamStub        func(teamName, name string) (bool, error)
+	renameTeamMutex       sync.RWMutex
+	renameTeamArgsForCall []struct {
+		teamName string
+		name     string
+	}
+	renameTeamReturns struct {
+		result1 bool
+		result2 error
+	}
+	renameTeamReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	DestroyTeamStub        func(teamName string) error
 	destroyTeamMutex       sync.RWMutex
 	destroyTeamArgsForCall []struct {
@@ -645,6 +659,58 @@ func (fake *FakeTeam) CreateOrUpdateReturnsOnCall(i int, result1 atc.Team, resul
 		result3 bool
 		result4 error
 	}{result1, result2, result3, result4}
+}
+
+func (fake *FakeTeam) RenameTeam(teamName string, name string) (bool, error) {
+	fake.renameTeamMutex.Lock()
+	ret, specificReturn := fake.renameTeamReturnsOnCall[len(fake.renameTeamArgsForCall)]
+	fake.renameTeamArgsForCall = append(fake.renameTeamArgsForCall, struct {
+		teamName string
+		name     string
+	}{teamName, name})
+	fake.recordInvocation("RenameTeam", []interface{}{teamName, name})
+	fake.renameTeamMutex.Unlock()
+	if fake.RenameTeamStub != nil {
+		return fake.RenameTeamStub(teamName, name)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.renameTeamReturns.result1, fake.renameTeamReturns.result2
+}
+
+func (fake *FakeTeam) RenameTeamCallCount() int {
+	fake.renameTeamMutex.RLock()
+	defer fake.renameTeamMutex.RUnlock()
+	return len(fake.renameTeamArgsForCall)
+}
+
+func (fake *FakeTeam) RenameTeamArgsForCall(i int) (string, string) {
+	fake.renameTeamMutex.RLock()
+	defer fake.renameTeamMutex.RUnlock()
+	return fake.renameTeamArgsForCall[i].teamName, fake.renameTeamArgsForCall[i].name
+}
+
+func (fake *FakeTeam) RenameTeamReturns(result1 bool, result2 error) {
+	fake.RenameTeamStub = nil
+	fake.renameTeamReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeTeam) RenameTeamReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.RenameTeamStub = nil
+	if fake.renameTeamReturnsOnCall == nil {
+		fake.renameTeamReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.renameTeamReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeTeam) DestroyTeam(teamName string) error {
@@ -2101,6 +2167,8 @@ func (fake *FakeTeam) Invocations() map[string][][]interface{} {
 	defer fake.authTokenMutex.RUnlock()
 	fake.createOrUpdateMutex.RLock()
 	defer fake.createOrUpdateMutex.RUnlock()
+	fake.renameTeamMutex.RLock()
+	defer fake.renameTeamMutex.RUnlock()
 	fake.destroyTeamMutex.RLock()
 	defer fake.destroyTeamMutex.RUnlock()
 	fake.pipelineMutex.RLock()

--- a/concourse/team.go
+++ b/concourse/team.go
@@ -14,6 +14,7 @@ type Team interface {
 	AuthToken() (atc.AuthToken, error)
 
 	CreateOrUpdate(team atc.Team) (atc.Team, bool, bool, error)
+	RenameTeam(teamName, name string) (bool, error)
 	DestroyTeam(teamName string) error
 
 	Pipeline(name string) (atc.Pipeline, bool, error)

--- a/concourse/teams.go
+++ b/concourse/teams.go
@@ -70,6 +70,32 @@ func (team *team) DestroyTeam(teamName string) error {
 	return err
 }
 
+func (team *team) RenameTeam(teamName, name string) (bool, error) {
+	params := rata.Params{
+		"team_name": teamName,
+	}
+
+	jsonBytes, err := json.Marshal(atc.RenameRequest{NewName: name})
+	if err != nil {
+		return false, err
+	}
+
+	err = team.connection.Send(internal.Request{
+		RequestName: atc.RenameTeam,
+		Params:      params,
+		Body:        bytes.NewBuffer(jsonBytes),
+		Header:      http.Header{"Content-Type": []string{"application/json"}},
+	}, nil)
+	switch err.(type) {
+	case nil:
+		return true, nil
+	case internal.ResourceNotFoundError:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
 func (client *client) ListTeams() ([]atc.Team, error) {
 	var teams []atc.Team
 	err := client.connection.Send(internal.Request{


### PR DESCRIPTION
Generated new mock objects to support rename team functions in ATC API and Fly CLI.

This PR depends on https://github.com/concourse/atc/pull/214 and https://github.com/concourse/fly/pull/196

See issue https://github.com/concourse/concourse/issues/694