### PR TITLE
Add Enable/DisableResourceVersion methods

### DIFF
--- a/concourse/resourceversions.go
+++ b/concourse/resourceversions.go
@@ -2,6 +2,7 @@ package concourse
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/concourse/atc"
 	"github.com/concourse/go-concourse/concourse/internal"
@@ -38,5 +39,51 @@ func (team *team) ResourceVersions(pipelineName string, resourceName string, pag
 		return versionedResources, Pagination{}, false, nil
 	default:
 		return versionedResources, Pagination{}, false, err
+	}
+}
+
+func (team *team) DisableResourceVersion(pipelineName string, resourceName string, resourceVersionID int) (bool, error) {
+	params := rata.Params{
+		"pipeline_name":       pipelineName,
+		"resource_name":       resourceName,
+		"resource_version_id": strconv.Itoa(resourceVersionID),
+		"team_name":           team.name,
+	}
+
+	err := team.connection.Send(internal.Request{
+		RequestName: atc.DisableResourceVersion,
+		Params:      params,
+	}, nil)
+
+	switch err.(type) {
+	case nil:
+		return true, nil
+	case internal.ResourceNotFoundError:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func (team *team) EnableResourceVersion(pipelineName string, resourceName string, resourceVersionID int) (bool, error) {
+	params := rata.Params{
+		"pipeline_name":       pipelineName,
+		"resource_name":       resourceName,
+		"resource_version_id": strconv.Itoa(resourceVersionID),
+		"team_name":           team.name,
+	}
+
+	err := team.connection.Send(internal.Request{
+		RequestName: atc.EnableResourceVersion,
+		Params:      params,
+	}, nil)
+
+	switch err.(type) {
+	case nil:
+		return true, nil
+	case internal.ResourceNotFoundError:
+		return false, nil
+	default:
+		return false, err
 	}
 }

--- a/concourse/team.go
+++ b/concourse/team.go
@@ -45,6 +45,8 @@ type Team interface {
 	VersionedResourceTypes(pipelineName string) (atc.VersionedResourceTypes, bool, error)
 	ResourceVersions(pipelineName string, resourceName string, page Page) ([]atc.VersionedResource, Pagination, bool, error)
 	CheckResource(pipelineName string, resourceName string, version atc.Version) (bool, error)
+	DisableResourceVersion(pipelineName string, resourceName string, resourceVersionID int) (bool, error)
+	EnableResourceVersion(pipelineName string, resourceName string, resourceVersionID int) (bool, error)
 
 	BuildsWithVersionAsInput(pipelineName string, resourceName string, resourceVersionID int) ([]atc.Build, bool, error)
 	BuildsWithVersionAsOutput(pipelineName string, resourceName string, resourceVersionID int) ([]atc.Build, bool, error)


### PR DESCRIPTION
Implement enable and disable of resource version as describe by the following atc routes :

```
 {Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id/enable", Method: "PUT", Name: EnableResourceVersion},
 {Path: "/api/v1/teams/:team_name/pipelines/:pipeline_name/resources/:resource_name/versions/:resource_version_id/disable", Method: "PUT", Name: DisableResourceVersion},
```