### PR TITLE
Add check credentials parameter to CreateOrUpdatePipelineConfig

### DIFF
--- a/concourse/team.go
+++ b/concourse/team.go
@@ -26,7 +26,7 @@ type Team interface {
 	UnpauseResource(pipelineName string, resourceName string) (bool, error)
 	ListPipelines() ([]atc.Pipeline, error)
 	PipelineConfig(pipelineName string) (atc.Config, atc.RawConfig, string, bool, error)
-	CreateOrUpdatePipelineConfig(pipelineName string, configVersion string, passedConfig []byte, skipCredentials bool) (bool, bool, []ConfigWarning, error)
+	CreateOrUpdatePipelineConfig(pipelineName string, configVersion string, passedConfig []byte, checkCredentials bool) (bool, bool, []ConfigWarning, error)
 
 	CreatePipelineBuild(pipelineName string, plan atc.Plan) (atc.Build, error)
 

--- a/concourse/team.go
+++ b/concourse/team.go
@@ -26,7 +26,7 @@ type Team interface {
 	UnpauseResource(pipelineName string, resourceName string) (bool, error)
 	ListPipelines() ([]atc.Pipeline, error)
 	PipelineConfig(pipelineName string) (atc.Config, atc.RawConfig, string, bool, error)
-	CreateOrUpdatePipelineConfig(pipelineName string, configVersion string, passedConfig []byte) (bool, bool, []ConfigWarning, error)
+	CreateOrUpdatePipelineConfig(pipelineName string, configVersion string, passedConfig []byte, skipCredentials bool) (bool, bool, []ConfigWarning, error)
 
 	CreatePipelineBuild(pipelineName string, plan atc.Plan) (atc.Build, error)
 


### PR DESCRIPTION
This add a ~~`skipCredentials`~~ `checkCredentials` parameter to CreateOrUpdatePipelineConfig, so that `fly` can opt to check server-side verification of credentials parameters.

This is for concourse/concourse#1920, and is intended to go with these other PRs:
concourse/atc#296
concourse/fly#252