### PR TITLE
Add API to support clearing of task caches from fly

### DIFF
--- a/concourse/jobs.go
+++ b/concourse/jobs.go
@@ -135,7 +135,7 @@ func (team *team) UnpauseJob(pipelineName string, jobName string) (bool, error) 
 	}
 }
 
-func (team *team) ClearTaskCache(pipelineName string, jobName string, stepName string, cachePath string) (bool, error) {
+func (team *team) ClearTaskCache(pipelineName string, jobName string, stepName string, cachePath string) (int64, error) {
 	params := rata.Params{
 		"team_name":     team.name,
 		"pipeline_name": pipelineName,
@@ -148,11 +148,11 @@ func (team *team) ClearTaskCache(pipelineName string, jobName string, stepName s
 		queryParams.Add(atc.ClearTaskCacheQueryPath, cachePath)
 	}
 
-	//var taskResponse atc.ConfigResponse
-
+	var ctcResponse atc.ClearTaskCacheResponse
 	responseHeaders := http.Header{}
 	response := internal.Response{
 		Headers: &responseHeaders,
+		Result:  &ctcResponse,
 	}
 	err := team.connection.Send(internal.Request{
 		RequestName: atc.ClearTaskCache,
@@ -160,12 +160,9 @@ func (team *team) ClearTaskCache(pipelineName string, jobName string, stepName s
 		Query:       queryParams,
 	}, &response)
 
-	switch err.(type) {
-	case nil:
-		return true, nil
-	case internal.ResourceNotFoundError:
-		return false, nil
-	default:
-		return false, err
+	if err != nil {
+		return 0, err
+	} else {
+		return ctcResponse.NumCacheRemoved, nil
 	}
 }

--- a/concourse/jobs.go
+++ b/concourse/jobs.go
@@ -2,6 +2,7 @@ package concourse
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/concourse/atc"
 	"github.com/concourse/go-concourse/concourse/internal"
@@ -123,6 +124,41 @@ func (team *team) UnpauseJob(pipelineName string, jobName string) (bool, error) 
 		RequestName: atc.UnpauseJob,
 		Params:      params,
 	}, &internal.Response{})
+
+	switch err.(type) {
+	case nil:
+		return true, nil
+	case internal.ResourceNotFoundError:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func (team *team) ClearTaskCache(pipelineName string, jobName string, stepName string, cachePath string) (bool, error) {
+	params := rata.Params{
+		"team_name":     team.name,
+		"pipeline_name": pipelineName,
+		"job_name":      jobName,
+		"step_name":     stepName,
+	}
+
+	queryParams := url.Values{}
+	if len(cachePath) > 0 {
+		queryParams.Add(atc.ClearTaskCacheQueryPath, cachePath)
+	}
+
+	//var taskResponse atc.ConfigResponse
+
+	responseHeaders := http.Header{}
+	response := internal.Response{
+		Headers: &responseHeaders,
+	}
+	err := team.connection.Send(internal.Request{
+		RequestName: atc.ClearTaskCache,
+		Params:      params,
+		Query:       queryParams,
+	}, &response)
 
 	switch err.(type) {
 	case nil:

--- a/concourse/jobs.go
+++ b/concourse/jobs.go
@@ -163,6 +163,6 @@ func (team *team) ClearTaskCache(pipelineName string, jobName string, stepName s
 	if err != nil {
 		return 0, err
 	} else {
-		return ctcResponse.NumCacheRemoved, nil
+		return ctcResponse.CachesRemoved, nil
 	}
 }

--- a/concourse/jobs_test.go
+++ b/concourse/jobs_test.go
@@ -484,7 +484,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest(requestMethod, expectedURL),
-						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ClearTaskCacheResponse{NumCacheRemoved: 1}),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ClearTaskCacheResponse{CachesRemoved: 1}),
 					),
 				)
 			})
@@ -523,7 +523,7 @@ var _ = Describe("ATC Handler Jobs", func() {
 				atcServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest(requestMethod, expectedURL),
-						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ClearTaskCacheResponse{NumCacheRemoved: 0}),
+						ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ClearTaskCacheResponse{CachesRemoved: 0}),
 					),
 				)
 			})

--- a/concourse/team.go
+++ b/concourse/team.go
@@ -41,7 +41,7 @@ type Team interface {
 	PauseJob(pipelineName string, jobName string) (bool, error)
 	UnpauseJob(pipelineName string, jobName string) (bool, error)
 
-	ClearTaskCache(pipelineName string, jobName string, stepName string, cachePath string) (bool, error)
+	ClearTaskCache(pipelineName string, jobName string, stepName string, cachePath string) (int64, error)
 
 	Resource(pipelineName string, resourceName string) (atc.Resource, bool, error)
 	VersionedResourceTypes(pipelineName string) (atc.VersionedResourceTypes, bool, error)

--- a/concourse/team.go
+++ b/concourse/team.go
@@ -41,6 +41,8 @@ type Team interface {
 	PauseJob(pipelineName string, jobName string) (bool, error)
 	UnpauseJob(pipelineName string, jobName string) (bool, error)
 
+	ClearTaskCache(pipelineName string, jobName string, stepName string, cachePath string) (bool, error)
+
 	Resource(pipelineName string, resourceName string) (atc.Resource, bool, error)
 	VersionedResourceTypes(pipelineName string) (atc.VersionedResourceTypes, bool, error)
 	ResourceVersions(pipelineName string, resourceName string, page Page) ([]atc.VersionedResource, Pagination, bool, error)


### PR DESCRIPTION
Add API to support clearing of task caches from `fly`. Supports concourse/concourse#1817.

Intended to go with:
concourse/atc#298
concourse/fly#254